### PR TITLE
Bumps MathieuSoysal/Javadoc-publisher.yml from 2.0.3 to 2.3.0

### DIFF
--- a/.github/workflows/manual-maven-compiler.yml
+++ b/.github/workflows/manual-maven-compiler.yml
@@ -31,4 +31,10 @@ jobs:
     - name: Build with Maven
       run: mvn package --file pom.xml
     - name: Deploy Javadoc
-      uses: MathieuSoysal/Javadoc-publisher.yml@v2.0.3
+      uses: MathieuSoysal/publish-javadoc@v2.3.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        javadoc-branche: javadoc
+        java-version: 8
+        target-folder: javadoc
+        java-distribution: zulu

--- a/.github/workflows/maven-compiler.yml
+++ b/.github/workflows/maven-compiler.yml
@@ -31,4 +31,10 @@ jobs:
     - name: Build with Maven
       run: mvn package --file pom.xml
     - name: Deploy Javadoc
-      uses: MathieuSoysal/Javadoc-publisher.yml@v2.0.3
+      uses: MathieuSoysal/publish-javadoc@v2.3.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        javadoc-branche: javadoc
+        java-version: 8
+        target-folder: javadoc
+        java-distribution: zulu

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository only serves the point of providing access to the method signatur
 
 <hr>
 <h3 align="center">
-<a href="https://itemsadder.devs.beer/developers/java-api">☕ Java documentation</a> | <a href="https://lonedev6.github.io/API-ItemsAdder/">☕ JavaDocs</a>  | <a href="https://itemsadder.devs.beer/developers/skript-api">📓 Skript documentation</a>
+<a href="https://itemsadder.devs.beer/developers/java-api">☕ Java documentation</a> | <a href="https://lonedev6.github.io/API-ItemsAdder/javadoc/">☕ JavaDocs</a>  | <a href="https://itemsadder.devs.beer/developers/skript-api">📓 Skript documentation</a>
 </h3>
 <hr> 
 


### PR DESCRIPTION
I'm principal contributor of MathieuSoysal/Javadoc-publisher.yml

I'm glad you found the action useful!  
And I wanted to help you to bump [MathieuSoysal/Javadoc-publisher.yml](https://github.com/MathieuSoysal/Javadoc-publisher.yml) from 2.0.3 to 2.3.0

<details>
<summary>Release notes</summary>

> # 06/12/2022 - JavaDoc Publisher  📦  2.3.0
> ### ✨ New features
> * __Add caching GitHub Actions__  - by @MathieuSoysal  
> * __Add Gradle support__  - by @MathieuSoysal 
> * __Add custom command__ - by @MathieuSoysal 

> ### 🔧 New updates
> * __Add United tests for GitHub Actions__ - by @MathieuSoysal 

</details>

____

The JavaDoc badge of your project : [![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](https://LoneDev6.github.io/API-ItemsAdder/javadoc/)

```
[![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](https://LoneDev6.github.io/API-ItemsAdder/javadoc/)
```
