### PR TITLE
Fix broken javadoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository only serves the point of providing access to the method signatur
 
 <hr>
 <h3 align="center">
-<a href="https://itemsadder.devs.beer/developers/java-api">☕ Java documentation</a> | <a href="https://lonedev6.github.io/API-ItemsAdder/javadoc/">☕ JavaDocs</a>  | <a href="https://itemsadder.devs.beer/developers/skript-api">📓 Skript documentation</a>
+<a href="https://itemsadder.devs.beer/developers/java-api">☕ Java documentation</a> | <a href="https://lonedev6.github.io/API-ItemsAdder/">☕ JavaDocs</a>  | <a href="https://itemsadder.devs.beer/developers/skript-api">📓 Skript documentation</a>
 </h3>
 <hr> 
 


### PR DESCRIPTION
The URL used is invalid. Instead https://lonedev6.github.io/API-ItemsAdder/ has to be used without the `javadoc/` suffix.