### PR TITLE
Fix Jitpak builds by not declaring the SNAPSHOT version of the AdventureAPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.17.0-SNAPSHOT</version>
+            <version>4.17.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Snapshot branch requires a specific repository declaration, and breaks jitpak builds. The currently declared snapshot version is already stable.

Fixes https://github.com/PluginBugs/Issues-ItemsAdder/issues/4020