### PR TITLE
Display badge with release on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This repository only serves the point of providing access to the method signatur
 
 
 ## ItemsAdder
+![maven release](https://img.shields.io/badge/dynamic/xml?url=https%3A%2F%2Fmaven.devs.beer%2Fdev%2Flone%2Fapi-itemsadder%2Fmaven-metadata.xml&query=%2F%2Fmetadata%2Fversioning%2Frelease&style=for-the-badge&label=API%20version
+)
+
 To build your project against this library, simply include one of the following references in your `pom.xml`:
 
 ```xml
@@ -23,12 +26,13 @@ To build your project against this library, simply include one of the following 
 </repository>
 ```
 
-In your **&lt;dependencies&gt;** section (To find the latest version checkl the [latest release](https://github.com/LoneDev6/API-ItemsAdder/releases) name):
+In your **&lt;dependencies&gt;** section (To find the latest version check the badge above):
 ```xml
 <dependency>
     <groupId>dev.lone</groupId>
     <artifactId>api-itemsadder</artifactId>
-    <version>4.0.2-beta-release-11</version>
+    <!-- Replace {version} with the latest version -->
+    <version>{version}</version>
     <scope>provided</scope>
 </dependency>
 ```


### PR DESCRIPTION
The GitHub repository is outdated in terms of releases, as the latest on the maven repo is 4.0.9 but here it's still 4.0.2-beta-release-11.

This PR updates the README to include a badge that fetches the latest release from the Maven repository's `maven-metadata.xml` file to display.
There probs is a better way to do this but without knowing what software is used for the repository, if any at all is used outside the apache server, is the current aproach the best option so far.